### PR TITLE
Add CORS headers

### DIFF
--- a/api/conf/application.conf
+++ b/api/conf/application.conf
@@ -1,1 +1,16 @@
 # https://www.playframework.com/documentation/latest/Configuration
+
+play.filters.enabled += "play.filters.cors.CORSFilter"
+
+# The default CORS configuration is permissive (all origins allowed, all HTTP
+# methods, all paths) and does what we need for now.
+# See https://www.playframework.com/documentation/2.8.x/CorsFilter
+#
+# To configure further: 
+# play.filters.cors {
+#   pathPrefixes = ["/some/path", ...]
+#   allowedOrigins = ["http://www.example.com", ...]
+#   allowedHttpMethods = ["GET", "POST"]
+#   allowedHttpHeaders = ["Accept"]
+#   preflightMaxAge = 3 days
+# }


### PR DESCRIPTION
Simply enabling the filter gets us permissive CORS behaviour (all origins, HTTP methods, paths) which is good enough for now.