### PR TITLE
Admin API endpoint to return a list of slots

### DIFF
--- a/api/app/controllers/SlotsAdminController.scala
+++ b/api/app/controllers/SlotsAdminController.scala
@@ -1,0 +1,19 @@
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+import play.api.libs.json._
+
+import automat.models.{SlotsStore, Slot}
+
+@Singleton
+class SlotsAdminController @Inject() (
+    val controllerComponents: ControllerComponents
+) extends BaseController {
+
+  def index = Action { implicit request: Request[AnyContent] =>
+    val resp = Json.toJson(Map("slots" -> SlotsStore.all))
+    Ok(resp)
+  }
+}

--- a/api/app/controllers/TestsAdminController.scala
+++ b/api/app/controllers/TestsAdminController.scala
@@ -8,8 +8,9 @@ import play.api.libs.json._
 import automat.models.{TestsStore, Test}
 
 @Singleton
-class TestsController @Inject() (val controllerComponents: ControllerComponents)
-    extends BaseController {
+class TestsAdminController @Inject() (
+    val controllerComponents: ControllerComponents
+) extends BaseController {
 
   def index(slotId: String) = Action { implicit request: Request[AnyContent] =>
     val resp = Json.toJson(Map("tests" -> TestsStore.getBySlotId(slotId)))

--- a/api/app/models/slot.scala
+++ b/api/app/models/slot.scala
@@ -1,0 +1,19 @@
+package automat.models
+
+import play.api.libs.json._
+
+final case class Slot(
+    id: String,
+    name: String
+)
+
+object Slot {
+  implicit val testFmt = Json.format[Slot]
+}
+
+object SlotsStore {
+  val mpu = Slot(id = "mpu", name = "MPU")
+  val bodyEnd = Slot(id = "bodyEnd", name = "Body End")
+
+  def all: List[Slot] = List(mpu, bodyEnd)
+}

--- a/api/app/models/test.scala
+++ b/api/app/models/test.scala
@@ -22,7 +22,7 @@ object TestsStore {
       Test(
         id = "test1",
         name = "Test 1",
-        slotId = "bodyEnd",
+        slotId = SlotsStore.bodyEnd.id,
         description = "example test",
         enabled = true,
         variants = List("foo", "bar"),
@@ -31,7 +31,7 @@ object TestsStore {
     "test2" -> Test(
       id = "test2",
       name = "Test 2",
-      slotId = "bodyEnd",
+      slotId = SlotsStore.bodyEnd.id,
       description = "example test",
       enabled = true,
       variants = List("foo", "bar"),
@@ -40,8 +40,8 @@ object TestsStore {
     "test3" ->
       Test(
         id = "test3",
-        name = "Test 2",
-        slotId = "cmp",
+        name = "Test 3",
+        slotId = SlotsStore.mpu.id,
         description = "example test",
         enabled = true,
         variants = List("foo", "bar"),
@@ -50,7 +50,7 @@ object TestsStore {
     "test4" -> Test(
       id = "test4",
       name = "Test 4",
-      slotId = "cmp",
+      slotId = SlotsStore.mpu.id,
       description = "example test",
       enabled = true,
       variants = List("foo", "bar"),

--- a/api/conf/routes
+++ b/api/conf/routes
@@ -1,9 +1,11 @@
 # Admin 
-GET     /admin/slots/:slotId/tests         controllers.TestsController.index(slotId)
-POST    /admin/slots/:slotId/tests         controllers.TestsController.create(slotId)
+GET     /admin/slots                       controllers.SlotsAdminController.index
 
-PATCH   /admin/tests/:testId               controllers.TestsController.update(testId)
-DELETE  /admin/tests/:testId               controllers.TestsController.delete(testId)
+GET     /admin/slots/:slotId/tests         controllers.TestsAdminController.index(slotId)
+POST    /admin/slots/:slotId/tests         controllers.TestsAdminController.create(slotId)
+
+PATCH   /admin/tests/:testId               controllers.TestsAdminController.update(testId)
+DELETE  /admin/tests/:testId               controllers.TestsAdminController.delete(testId)
 
 # Public
 POST    /slots                             controllers.SlotsController.create


### PR DESCRIPTION
Very basic first pass at an admin API endpoint to return a list of slots (backed by hardcoded/in memory data):

```
GET /admin/slots

{
    "slots": [
        {
            "id": "cmp",
            "name": "CMP"
        },
        {
            "id": "bodyEnd",
            "name": "Body End"
        }
    ]
}
```