### PR TITLE
Add `PATCH /admin/tests/:id` to update a test

### DIFF
--- a/api/conf/application.conf
+++ b/api/conf/application.conf
@@ -14,3 +14,5 @@ play.filters.enabled += "play.filters.cors.CORSFilter"
 #   allowedHttpHeaders = ["Accept"]
 #   preflightMaxAge = 3 days
 # }
+
+play.http.errorHandler = play.api.http.JsonHttpErrorHandler


### PR DESCRIPTION
Also introduce a separation between the params we want to accept on updating and creating a test and the test itself (guards against vulnerabilities like [mass-assignment](https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html) and also in general feels like good practice).

Example:

```
PATCH /admin/tests/test1
{
    "name": "Test 1 New Name"
}

200 OK
{
    "test": {
        "id": "test1",
        "name": "Test 1 New Name",
        "slotId": "bodyEnd",
        "description": "example test",
        "enabled": true,
        "variants": [
            "foo",
            "bar"
        ],
        "sections": [
            "culture"
        ]
    }
}
```