### PR TITLE
Interfaces and fake server data

### DIFF
--- a/fake-server/db.json
+++ b/fake-server/db.json
@@ -1,0 +1,121 @@
+{
+  "slots": [
+    {
+      "id": "mpu",
+      "name": "Article MPU"
+    }
+  ],
+  "tests": [
+    {
+      "id": "abcde123",
+      "name": "Subscriptions A/B Test",
+      "description": "Testing different messages for a subset of users likely to subscribe.",
+      "isEnabled": true,
+      "created": "2020-02-14T16:30:00",
+      "updated": "2020-06-01T09:15:00",
+      "author": {
+        "id": "andre.silva.freelancer@guarian.co.uk",
+        "firstName": "Andre",
+        "lastName": "Silva"
+      },
+      "variants": ["subsmpu"],
+      "filters": [
+        {
+          "filterId": "authstatus",
+          "selectedOptionIds": ["loggedin"]
+        },
+        {
+          "filterId": "subspropensity",
+          "selectedOptionIds": ["hot", "warm"]
+        },
+        {
+          "filterId": "samplerate",
+          "selectedOptionIds": ["25"]
+        }
+      ]
+    }
+  ],
+  "variants": [
+    {
+      "id": "subsmpu",
+      "name": "Subscriptions MPU",
+      "description": "A Guardian subscriptions advert in MPU format.",
+      "thumbnailUrl": "https://via.placeholder.com/300"
+    }
+  ],
+  "filters": [
+    {
+      "id": "authstatus",
+      "name": "Authentication Status",
+      "helpText": "Restrict the test audience to logged-in or not logged-in users.",
+      "allowMultiple": false,
+      "options": [
+        {
+          "value": "loggedin",
+          "label": "Logged In users only"
+        },
+        {
+          "value": "notloggedin",
+          "label": "Not logged-in users only"
+        },
+        {
+          "value": "any",
+          "label": "Any (it doesn't matter)",
+          "selected": true
+        }
+      ]
+    },
+    {
+      "id": "subspropensity",
+      "name": "Propensity to Subscribe",
+      "helpText": "Restrict the test audience to users who fit into a given propensity level.",
+      "allowMultiple": true,
+      "options": [
+        {
+          "value": "hot",
+          "label": "Hot (very likely to subscribe)",
+          "selected": true
+        },
+        {
+          "value": "warm",
+          "label": "Warm (likely to subscribe)",
+          "selected": true
+        },
+        {
+          "value": "cold",
+          "label": "Cold (unlikely to subscribe)",
+          "selected": true
+        }
+      ]
+    },
+    {
+      "id": "samplerate",
+      "name": "Custom Sampling Rate",
+      "helpText": "Restrict the test audience to a percentage of users in the cohort.",
+      "allowMultiple": false,
+      "options": [
+        {
+          "value": "100",
+          "label": "100%",
+          "selected": true
+        },
+        {
+          "value": "50",
+          "label": "50%"
+        },
+        {
+          "value": "25",
+          "label": "25%"
+        },
+        {
+          "value": "10",
+          "label": "10%"
+        },
+        {
+          "value": "5",
+          "label": "5%"
+        }
+      ]
+    }
+  ]
+}

--- a/fake-server/types.ts
+++ b/fake-server/types.ts
@@ -4,7 +4,6 @@ type Slots = Slot[];
 export interface Slot {
   id: string;
   name: string;
-  tests: Test[];
 }
 
 // GET /admin/slots/:slotId/tests
@@ -19,11 +18,11 @@ export interface Test {
   created: Date;
   updated: Date;
   author: {
-    id: string; // Like to be email address
+    id: string; // Likely email address
     firstName: string;
     lastName: string;
   };
-  variants: string[]; // Array of component IDs
+  variants: string[]; // Array of variant IDs (components)
   filters: TestFilter[];
 }
 
@@ -39,7 +38,7 @@ interface Filter {
   name: string;
   helpText: string;
   options: FilterOption[];
-  allowMultiple: boolean; // Default to false
+  allowMultiple: boolean; // Default to false?
 }
 interface FilterOption {
   value: string;

--- a/fake-server/types.ts
+++ b/fake-server/types.ts
@@ -1,0 +1,56 @@
+// GET /admin/slots
+// Returns an array of Automat slots.
+type Slots = Slot[];
+export interface Slot {
+  id: string;
+  name: string;
+  tests: Test[];
+}
+
+// GET /admin/slots/:slotId/tests
+// Returns an array of tests under the slot.
+// PUT /admin/slots/:slotId/tests
+// Updates the array of tests under the slot.
+export interface Test {
+  id: string;
+  name: string;
+  description: string;
+  isEnabled: boolean;
+  created: Date;
+  updated: Date;
+  author: {
+    id: string; // Like to be email address
+    firstName: string;
+    lastName: string;
+  };
+  variants: string[]; // Array of component IDs
+  filters: TestFilter[];
+}
+
+interface TestFilter {
+  filterId: string;
+  selectedOptionIds: string[]; // Allow one or multiple entries depending on allowMultiple boolean in Filter
+}
+
+// GET /admin/filters
+type Filters = Filter[];
+interface Filter {
+  id: string;
+  name: string;
+  helpText: string;
+  options: FilterOption[];
+  allowMultiple: boolean; // Default to false
+}
+interface FilterOption {
+  value: string;
+  label: string;
+}
+
+// GET /admin/variants
+type Variants = Variant[];
+interface Variant {
+  id: string;
+  name: string;
+  description: string;
+  thumbnailUrl: string;
+}


### PR DESCRIPTION
Adds a temporary `fake-server` folder, containing a TS file with some interfaces representing our data structures, plus a `db.json` file containing the data used by the fake server to enable a functional REST API.

The `db.json` file can be used with this module to spin up a functional REST API:
https://www.npmjs.com/package/json-server