### PR TITLE
Re-add `POST /slots`

### DIFF
--- a/api/app/controllers/SlotsController.scala
+++ b/api/app/controllers/SlotsController.scala
@@ -2,8 +2,10 @@ package controllers
 
 import persistence.SlotStore
 import play.api.mvc._
+import play.api.libs.json._
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.ExecutionContext
+import models.{Targeting, Test}
 
 class SlotsController(
     val controllerComponents: ControllerComponents,
@@ -12,5 +14,24 @@ class SlotsController(
     implicit ec: ExecutionContext
 ) extends BaseController {
 
-  def create() = Action.async { implicit request: Request[AnyContent] => ??? }
+  def create() = Action.async { implicit request: Request[AnyContent] =>
+    val targeting =
+      for {
+        json <- request.body.asJson
+        targeting <- Json.fromJson[Targeting](json).asOpt
+      } yield targeting
+
+    targeting match {
+      case Some(targeting) =>
+        store.getAllSlots().map { slots =>
+          val slotPairs = slots.map { slot =>
+            val matchingTests = Targeting.findMatches(targeting, slot.tests)
+            (slot.id -> matchingTests.headOption)
+          }
+
+          Ok(Json.toJson(slotPairs.toMap))
+        }
+      case None => Future.successful(BadRequest(Json.toJson(None)))
+    }
+  }
 }


### PR DESCRIPTION
## What does this change?

Re-add the basic behaviour for `POST /slots`. This was removed temporarily to simplify the elastic search integration added in #17. Add it back in a way that works with the new store interface.
