### PR TITLE
Validate variants

### DIFF
--- a/api/app/controllers/SlotsAdminController.scala
+++ b/api/app/controllers/SlotsAdminController.scala
@@ -4,10 +4,11 @@ import javax.inject._
 import play.api.libs.json._
 import play.api.mvc._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{Future, ExecutionContext}
+import scala.util.{Success, Failure}
 
-import models.{Slot, Test}
-import persistence.{SlotStore}
+import models.{Slot, Test, Validation}
+import persistence.{Store}
 
 case class SlimSlot(
     id: String,
@@ -37,7 +38,7 @@ object SlotUpdateParams {
 
 class SlotsAdminController(
     val controllerComponents: ControllerComponents,
-    val store: SlotStore
+    val store: Store
 )(implicit ec: ExecutionContext)
     extends BaseController {
 
@@ -66,16 +67,44 @@ class SlotsAdminController(
 
   def update(slotId: String) = Action.async(parse.json[SlotUpdateParams]) {
     implicit request =>
-      val resp = store.getSlot(slotId)
+      val updatedSlot = for {
+        slot <- store.getSlot(slotId).flatMap(handleNotFound)
+        updated = SlotUpdateParams.toSlot(request.body, slot)
+        _ <- handleValidationErrors(Slot.validate(updated, store))
+        _ <- store.updateSlot(slotId, updated)
+      } yield updated
 
-      resp map { slot =>
-        slot match {
-          case Some(slot) =>
-            val updatedSlot = SlotUpdateParams.toSlot(request.body, slot)
-            store.updateSlot(slotId, updatedSlot)
-            Ok(Json.toJson(Map("slot" -> updatedSlot)))
-          case None => NotFound
-        }
-      }
+      updatedSlot.map(asSuccessResponse).recover(handleErrors)
+  }
+
+  def asSuccessResponse(slot: Slot): Result =
+    Ok(Json.toJson(Map("slot" -> slot)))
+
+  def handleErrors: PartialFunction[Throwable, Result] = {
+    case ValidationException(_) => BadRequest
+    case NotFoundException(_)   => NotFound
+    case _                      => InternalServerError
+  }
+
+  case class ValidationException(message: String) extends Exception
+  case class NotFoundException(message: String) extends Exception
+
+  def handleNotFound[T](slotOpt: Option[T]): Future[T] = {
+    toFut(slotOpt, new NotFoundException("Not found"))
+  }
+
+  def handleValidationErrors(f: Future[Validation]): Future[Unit] =
+    f.transform {
+      case Success(models.Success) => Success(())
+      case Success(models.Failure(message)) =>
+        Failure(new ValidationException(message))
+      case Failure(message) => Failure(message)
+    }
+
+  def toFut[T](option: Option[T], e: Exception): Future[T] = {
+    option match {
+      case Some(a) => Future.successful(a)
+      case _       => Future.failed(e)
+    }
   }
 }

--- a/api/app/models/Validation.scala
+++ b/api/app/models/Validation.scala
@@ -1,0 +1,5 @@
+package models
+
+sealed trait Validation
+final case object Success extends Validation
+final case class Failure(message: String) extends Validation

--- a/api/test/controllers/SlotsAdminControllerSpec.scala
+++ b/api/test/controllers/SlotsAdminControllerSpec.scala
@@ -1,16 +1,21 @@
 package controllers
 
+import org.scalatest.concurrent._
 import org.scalatestplus.play._
 import play.api.libs.json._
 import play.api.test._
 import play.api.test.Helpers._
+import akka.actor.ActorSystem
+import akka.stream.Materializer
 
 import models.{Slot, Test}
 import persistence.MemoryStore
 
-class SlotsAdminControllerSpec extends PlaySpec {
+class SlotsAdminControllerSpec extends PlaySpec with ScalaFutures {
   implicit val ec: scala.concurrent.ExecutionContext =
     scala.concurrent.ExecutionContext.global
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val materializer: Materializer = Materializer(system)
 
   "SlotsAdminController GET index" should {
     "return a list of variants" in {
@@ -19,7 +24,8 @@ class SlotsAdminControllerSpec extends PlaySpec {
       val controller =
         new SlotsAdminController(stubControllerComponents(), store)
 
-      val slotsIndex = controller.index().apply(FakeRequest(GET, "/"))
+      val slotsIndex =
+        controller.index().apply(FakeRequest(GET, "/admin/slots"))
 
       status(slotsIndex) mustBe OK
       contentType(slotsIndex) mustBe Some("application/json")
@@ -44,7 +50,8 @@ class SlotsAdminControllerSpec extends PlaySpec {
       val controller =
         new SlotsAdminController(stubControllerComponents(), store)
 
-      val slotsGet = controller.get("mpu").apply(FakeRequest(GET, "/"))
+      val slotsGet =
+        controller.get("mpu").apply(FakeRequest(GET, "/admin/slots/mpu"))
 
       status(slotsGet) mustBe OK
       contentType(slotsGet) mustBe Some("application/json")
@@ -78,9 +85,91 @@ class SlotsAdminControllerSpec extends PlaySpec {
       val controller =
         new SlotsAdminController(stubControllerComponents(), store)
 
-      val slotsGet = controller.get("badSlotId").apply(FakeRequest(GET, "/"))
+      val slotsGet = controller
+        .get("badSlotId")
+        .apply(FakeRequest(GET, "/admin/slots/badSlotId"))
 
       status(slotsGet) mustBe NOT_FOUND
+    }
+  }
+
+  "SlotsAdminController PATCH update" should {
+    "update a slot when the payload is valid" in {
+      val store = MemoryStore()
+      store.populate()
+      val controller =
+        new SlotsAdminController(stubControllerComponents(), store)
+      val test = Test(
+        id = "test1",
+        name = "Test 1",
+        description = "example test",
+        isEnabled = true,
+        variants = List("subsmpu"),
+        sections = List("culture")
+      )
+      val payload = SlotUpdateParams(tests = List(test))
+      val request = FakeRequest(PATCH, "/admin/slots/mpu")
+        .withBody(payload)
+        .withHeaders(CONTENT_TYPE -> "application/json")
+
+      val slotsUpdate = controller.update("mpu").apply(request)
+
+      status(slotsUpdate) mustBe OK
+      whenReady(slotsUpdate) { _ =>
+        val slotOption = store.getSlot("mpu")
+
+        whenReady(slotOption) { slotOption =>
+          slotOption must not be None
+          slotOption.map { slot => slot.tests mustBe List(test) }
+        }
+      }
+    }
+
+    "return a 400 when the payload is not valid" in {
+      val store = MemoryStore()
+      store.populate()
+      val controller =
+        new SlotsAdminController(stubControllerComponents(), store)
+      val badVariantId = "badVariant"
+      val test = Test(
+        id = "test1",
+        name = "Test 1",
+        description = "example test",
+        isEnabled = true,
+        variants = List(badVariantId),
+        sections = List("culture")
+      )
+      val payload = SlotUpdateParams(tests = List(test))
+      val request = FakeRequest(PATCH, "/admin/slots/mpu")
+        .withBody(payload)
+        .withHeaders(CONTENT_TYPE -> "application/json")
+
+      val slotsUpdate = controller.update("mpu").apply(request)
+
+      status(slotsUpdate) mustBe BAD_REQUEST
+    }
+
+    "return a 404 when the slot doesn't exist" in {
+      val store = MemoryStore()
+      store.populate()
+      val controller =
+        new SlotsAdminController(stubControllerComponents(), store)
+      val test = Test(
+        id = "test1",
+        name = "Test 1",
+        description = "example test",
+        isEnabled = true,
+        variants = List("subsmpu"),
+        sections = List("culture")
+      )
+      val payload = SlotUpdateParams(tests = List(test))
+      val request = FakeRequest(PATCH, "/admin/slots/xxx")
+        .withBody(payload)
+        .withHeaders(CONTENT_TYPE -> "application/json")
+
+      val slotsUpdate = controller.update("xxx").apply(request)
+
+      status(slotsUpdate) mustBe NOT_FOUND
     }
   }
 

--- a/api/test/models/SlotSpec.scala
+++ b/api/test/models/SlotSpec.scala
@@ -1,0 +1,61 @@
+package models
+
+import org.scalatest.AsyncFlatSpec
+import scala.concurrent.Future
+import play.api.test._
+import play.api.test.Helpers._
+
+import persistence.MemoryStore
+
+class SlotSpec extends AsyncFlatSpec {
+  implicit val ec: scala.concurrent.ExecutionContext =
+    scala.concurrent.ExecutionContext.global
+
+  behavior of "validate"
+  it should "return Success when the slot is valid" in {
+    val store = MemoryStore()
+    store.populate()
+    val validSlot = Slot(
+      id = "mpu",
+      name = "MPU",
+      tests = List(
+        Test(
+          id = "test",
+          name = "A test",
+          description = "Example test",
+          isEnabled = true,
+          variants = List("subsmpu"),
+          sections = List("cricket")
+        )
+      )
+    )
+
+    val futureResult = Slot.validate(validSlot, store)
+
+    futureResult map { result => assert(result == Success) }
+  }
+
+  it should "return Failure when the slot data is not valid" in {
+    val store = MemoryStore()
+    val invalidSlot = Slot(
+      id = "mpu",
+      name = "MPU",
+      tests = List(
+        Test(
+          id = "test",
+          name = "A test",
+          description = "Example test",
+          isEnabled = true,
+          variants = List("badVariant"),
+          sections = List("cricket")
+        )
+      )
+    )
+
+    val futureResult = Slot.validate(invalidSlot, store)
+
+    futureResult map { result =>
+      assert(result == Failure("slot references invalid variant(s)"))
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Adds some very basic/naive validation of variant IDs when updating slot tests. Previously variant IDs were not validated. Now we check that they correspond to a variant which exists before allowing the update through.

We're not giving back anything meaningful in the error response body (yet) - just conveying the error with a 400 Bad Request response code.

## How can we measure success?

Slot tests should not contain invalid variant IDs.
