### PR TITLE
A couple of small API tweaks

### DIFF
--- a/api/app/controllers/SlotsAdminController.scala
+++ b/api/app/controllers/SlotsAdminController.scala
@@ -11,14 +11,15 @@ import persistence.{SlotStore}
 
 case class SlimSlot(
     id: String,
-    name: String
+    name: String,
+    testCount: Int
 )
 
 object SlimSlot {
   implicit val testFmt = Json.format[SlimSlot]
 
   def fromSlot(slot: Slot): SlimSlot =
-    SlimSlot(id = slot.id, name = slot.name)
+    SlimSlot(id = slot.id, name = slot.name, testCount = slot.tests.length)
 }
 
 case class SlotUpdateParams(

--- a/api/app/models/targeting.scala
+++ b/api/app/models/targeting.scala
@@ -10,5 +10,6 @@ object Targeting {
   implicit val targetingFmt = Json.format[Targeting]
 
   def findMatches(targeting: Targeting, tests: List[Test]): List[Test] =
-    tests.filter(_.sections.contains(targeting.section))
+    tests
+  // tests.filter(_.sections.contains(targeting.section))
 }

--- a/api/app/models/test.scala
+++ b/api/app/models/test.scala
@@ -2,12 +2,23 @@ package models
 
 import play.api.libs.json._
 
+case class Author(
+    id: String,
+    firstName: String,
+    lastName: String
+)
+
+object Author {
+  implicit val authorFmt = Json.format[Author]
+}
+
 case class Test(
     id: String,
     name: String,
     description: String,
     isEnabled: Boolean,
-    variants: List[String]
+    variants: List[String],
+    author: Author
 )
 
 object Test {

--- a/api/app/models/test.scala
+++ b/api/app/models/test.scala
@@ -7,8 +7,7 @@ case class Test(
     name: String,
     description: String,
     isEnabled: Boolean,
-    variants: List[String],
-    sections: List[String]
+    variants: List[String]
 )
 
 object Test {

--- a/api/app/persistence/Store.scala
+++ b/api/app/persistence/Store.scala
@@ -18,7 +18,7 @@ import play.api.libs.json._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-import models.{Slot, Test, Variant}
+import models.{Author, Slot, Test, Variant}
 
 trait SlotStore {
   def getAllSlots(): Future[List[Slot]]
@@ -216,14 +216,24 @@ object TestData {
           name = "Test 1",
           description = "example test",
           isEnabled = true,
-          variants = List("subsmpu")
+          variants = List("subsmpu"),
+          author = Author(
+            id = "example.user@guardian.co.uk",
+            firstName = "Example",
+            lastName = "User"
+          )
         ),
         Test(
           id = "test2",
           name = "Test 2",
           description = "example test",
           isEnabled = true,
-          variants = List("subsmpu")
+          variants = List("subsmpu"),
+          author = Author(
+            id = "example.user@guardian.co.uk",
+            firstName = "Example",
+            lastName = "User"
+          )
         )
       )
     ),
@@ -236,14 +246,24 @@ object TestData {
           name = "Test 3",
           description = "example test",
           isEnabled = true,
-          variants = List("contributionsepic")
+          variants = List("contributionsepic"),
+          author = Author(
+            id = "example.user@guardian.co.uk",
+            firstName = "Example",
+            lastName = "User"
+          )
         ),
         Test(
           id = "test4",
           name = "Test 4",
           description = "example test",
           isEnabled = true,
-          variants = List("contributionsepic")
+          variants = List("contributionsepic"),
+          author = Author(
+            id = "example.user@guardian.co.uk",
+            firstName = "Example",
+            lastName = "User"
+          )
         )
       )
     )

--- a/api/app/persistence/Store.scala
+++ b/api/app/persistence/Store.scala
@@ -216,16 +216,14 @@ object TestData {
           name = "Test 1",
           description = "example test",
           isEnabled = true,
-          variants = List("subsmpu"),
-          sections = List("culture")
+          variants = List("subsmpu")
         ),
         Test(
           id = "test2",
           name = "Test 2",
           description = "example test",
           isEnabled = true,
-          variants = List("subsmpu"),
-          sections = List("football")
+          variants = List("subsmpu")
         )
       )
     ),
@@ -238,16 +236,14 @@ object TestData {
           name = "Test 3",
           description = "example test",
           isEnabled = true,
-          variants = List("contributionsepic"),
-          sections = List("culture")
+          variants = List("contributionsepic")
         ),
         Test(
           id = "test4",
           name = "Test 4",
           description = "example test",
           isEnabled = true,
-          variants = List("contributionsepic"),
-          sections = List("cricket")
+          variants = List("contributionsepic")
         )
       )
     )

--- a/api/test/targeting_spec.scala
+++ b/api/test/targeting_spec.scala
@@ -10,21 +10,19 @@ class TargetingSpec extends PlaySpec {
         name = "Test 1",
         description = "example test",
         isEnabled = true,
-        variants = List("foo", "bar"),
-        sections = List("culture")
+        variants = List("foo", "bar")
       )
       val test2 = Test(
         id = "test2",
         name = "Test 2",
         description = "example test",
         isEnabled = true,
-        variants = List("foo", "bar"),
-        sections = List("football")
+        variants = List("foo", "bar")
       )
 
       val matches = Targeting.findMatches(targeting, List(test1, test2))
 
-      matches mustBe List(test2)
+      matches mustBe List(test1, test2)
     }
     "return an empty list when there are no matches" in {
       val targeting = new Targeting(section = "cycling")
@@ -33,21 +31,19 @@ class TargetingSpec extends PlaySpec {
         name = "Test 1",
         description = "example test",
         isEnabled = true,
-        variants = List("foo", "bar"),
-        sections = List("culture")
+        variants = List("foo", "bar")
       )
       val test2 = Test(
         id = "test2",
         name = "Test 2",
         description = "example test",
         isEnabled = true,
-        variants = List("foo", "bar"),
-        sections = List("football")
+        variants = List("foo", "bar")
       )
 
       val matches = Targeting.findMatches(targeting, List(test1, test2))
 
-      matches mustBe List()
+      matches mustBe List(test1, test2)
     }
   }
 }

--- a/api/test/targeting_spec.scala
+++ b/api/test/targeting_spec.scala
@@ -5,19 +5,13 @@ class TargetingSpec extends PlaySpec {
   "findMatches" must {
     "return a list of matching tests" in {
       val targeting = new Targeting(section = "football")
-      var test1 = Test(
+      var test1 = buildTest(
         id = "test1",
-        name = "Test 1",
-        description = "example test",
-        isEnabled = true,
-        variants = List("foo", "bar")
+        name = "Test 1"
       )
-      val test2 = Test(
+      val test2 = buildTest(
         id = "test2",
-        name = "Test 2",
-        description = "example test",
-        isEnabled = true,
-        variants = List("foo", "bar")
+        name = "Test 2"
       )
 
       val matches = Targeting.findMatches(targeting, List(test1, test2))
@@ -26,19 +20,13 @@ class TargetingSpec extends PlaySpec {
     }
     "return an empty list when there are no matches" in {
       val targeting = new Targeting(section = "cycling")
-      var test1 = Test(
+      var test1 = buildTest(
         id = "test1",
-        name = "Test 1",
-        description = "example test",
-        isEnabled = true,
-        variants = List("foo", "bar")
+        name = "Test 1"
       )
-      val test2 = Test(
+      val test2 = buildTest(
         id = "test2",
-        name = "Test 2",
-        description = "example test",
-        isEnabled = true,
-        variants = List("foo", "bar")
+        name = "Test 2"
       )
 
       val matches = Targeting.findMatches(targeting, List(test1, test2))
@@ -46,4 +34,25 @@ class TargetingSpec extends PlaySpec {
       matches mustBe List(test1, test2)
     }
   }
+
+  def buildTest(
+      id: String = "test",
+      name: String = "Test",
+      description: String = "Example test",
+      isEnabled: Boolean = true,
+      variants: List[String] = List("foo", "bar"),
+      author: Author = Author(
+        id = "example.user@guardian.co.uk",
+        firstName = "Example",
+        lastName = "User"
+      )
+  ): Test =
+    Test(
+      id = id,
+      name = name,
+      description = description,
+      isEnabled = isEnabled,
+      variants = variants,
+      author = author
+    )
 }


### PR DESCRIPTION
## What does this change?

* Adds `testCount` to the `SlimSlot` model
* Removes `sections` as an attribute of a `Test`. This will be replaced with filters going forward, but removing it unblocks some UI functionality in the meantime (note that this breaks some of the targeting functionality, but I figure that's okay since we'll be revisiting that with filters anyway).
* Adds an author to tests (for now provided by the UI, but in future will be derived from auth token or similar)
