### PR TITLE
Deletes hardcoded dummy filters in Test

### DIFF
--- a/ui/src/screens/Tests.tsx
+++ b/ui/src/screens/Tests.tsx
@@ -79,16 +79,7 @@ export const TestsScreen = ({ slots, variants, filters }: Props) => {
       const testsWithDummyFilters = data.slot.tests.map((test: TestFilter) => {
         const extendedTest = {
           ...test,
-          filters: [
-            {
-              filterId: 'authstatus',
-              selectedOptionIds: ['loggedin'],
-            },
-            {
-              filterId: 'subspropensity',
-              selectedOptionIds: ['hot', 'warm'],
-            },
-          ],
+          filters: [],
         };
         return extendedTest;
       });


### PR DESCRIPTION
## What does this change?
Deletes an hardcoded array of filters that was set to help test the Filters UI. Instead replaces it with an empty `filters` array so we can use the mapping logic downstream (albeit over an empty array every time we fetch the tests as the API doesn't persist filters yet).

## How can we measure success?
Ability to add/remove/update filters (without persistence).
