### PR TITLE
Update API url to use prod url

### DIFF
--- a/ui/.env
+++ b/ui/.env
@@ -1,1 +1,1 @@
-REACT_APP_AUTOMAT_API_URL="http://localhost:9000"
+REACT_APP_AUTOMAT_API_URL="http://front-lb8a1-yxrapyqxagbq-1683299063.eu-west-1.elb.amazonaws.com"


### PR DESCRIPTION
## What does this change?
Updates the API URL in the (only) .env file to use the PROD API URL. This is to be deployed to prod. The expectation is that we'll override this variable locally if we want to use anything other than the PROD api when we run the app locally.
